### PR TITLE
refactor(focal people): cleanup unused codes and fix typos

### DIFF
--- a/src/Stakeholders/components/FocalPeople/List/index.js
+++ b/src/Stakeholders/components/FocalPeople/List/index.js
@@ -211,7 +211,7 @@ class FocalPersonsList extends Component {
               },
               () => {
                 notifyError(
-                  'An Error occurred while refreshing Focal People please focalPerson system administrator'
+                  'An Error occurred while refreshing Focal People please contact system administrator'
                 );
               }
             )
@@ -272,7 +272,7 @@ class FocalPersonsList extends Component {
                   },
                   () => {
                     notifyError(
-                      'An Error occurred while archiving Focal Person please focalPerson system administrator'
+                      'An Error occurred while archiving Focal Person please contact system administrator'
                     );
                   }
                 )

--- a/src/Stakeholders/components/FocalPeople/ListItem/index.js
+++ b/src/Stakeholders/components/FocalPeople/ListItem/index.js
@@ -165,15 +165,6 @@ class FocalPeopleListItem extends Component {
           <Col span={1}>
             {isHovered && (
               <ListItemActions
-                onEdit={onEdit}
-                editActionName="Edit Focal Person"
-                editActionTitle="Edit Focal Person"
-                onShare={onShare}
-                shareActionName="Share Focal Person"
-                shareActionTitle="Share Focal Person"
-                onArchive={this.showArchiveConfirm}
-                archiveActionName="Archive Focal Person"
-                archiveActionTitle="Archive Focal Person"
                 edit={{
                   name: 'Edit Focal Person',
                   title: 'Update Focal Person Details',


### PR DESCRIPTION
This PR does the following
- Cleanup Focal People list item
- Fix typos on the feedback message when error occurs during creation and edit action